### PR TITLE
Fix storing of image files to store in correct directory

### DIFF
--- a/bird_classify.py
+++ b/bird_classify.py
@@ -41,7 +41,7 @@ def save_data(image,results,path,ext='png'):
     """Saves camera frame and model inference results
     to user-defined storage directory."""
     tag = '%010d' % int(time.monotonic()*1000)
-    name = '%simg-%s.%s' %(path,tag,ext)
+    name = '%s/img-%s.%s' %(path,tag,ext)
     image.save(name)
     print('Frame saved as: %s' %name)
     logging.info('Image: %s Results: %s', tag,results)


### PR DESCRIPTION
The default values in birdfeeder.sh work correctly for storing
results.log _inside_ of sdcard_directory.  But there is a typo of a
missing dir separator for storing the images.  So they were incorrectly
being stored one level up from their intended location and with an
incorrect name.