### PR TITLE
fix deprecation warning

### DIFF
--- a/bird_classify.py
+++ b/bird_classify.py
@@ -116,7 +116,7 @@ def main():
         nonlocal last_time
         nonlocal last_results
         start_time = time.monotonic()
-        results = engine.ClassifyWithImage(image, threshold=args.threshold, top_k=args.top_k)
+        results = engine.classify_with_image(image, threshold=args.threshold, top_k=args.top_k)
         end_time = time.monotonic()
         results = [(labels[i], score) for i, score in results]
 


### PR DESCRIPTION
The existing code was emitting the following into results.log:

```
2020-01-08 19:02:26,286-From bird_classify.py:119: The name ClassifyWithImage will be deprecated. Please use classify_with_image instead.
```